### PR TITLE
Automatic BPM and Note Spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,9 +123,9 @@
       <input type="number" id="difficulty" name="difficulty" value="5" min="1" max="10">
 
       <abbr
-        title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If unsure, set this to 180 and adjust from there.">i</abbr>
+        title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If left blank it the spacing will be automatically calculated based on BPM.">i</abbr>
       <label for="notespacing">Note Spacing</label>
-      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" value="180">
+      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" placeholder="Auto">
 
       <abbr title="Color of the start of the note">i</abbr>
       <label for="notestartcolor">Note Start Color</label>
@@ -285,6 +285,10 @@
 
   <div class="container">
     <h2>Version history</h2>
+    <p>
+      v1.9b<br>
+      Made Note Spacing optional. Default will automatically calculate based on 100/BPM*300
+    </p>
     <p>
       v1.9a<br>
       Increased maximum pitch bend range to 12 semitones

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
       <input type="number" id="difficulty" name="difficulty" value="5" min="1" max="10">
 
       <abbr
-        title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If left blank it the spacing will be automatically calculated based on BPM.">i</abbr>
+        title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If left blank the spacing will be automatically calculated based on BPM.">i</abbr>
       <label for="notespacing">Note Spacing</label>
       <input type="number" id="notespacing" name="notespacing" min="1" max="1000" placeholder="Auto">
 

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
         <option value="12">12</option>
       </select>
     </div>
+
     <div id="midiwarnings" class="warnings"></div>
   </div>
 
@@ -125,7 +126,7 @@
       <abbr
         title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If left blank the spacing will be automatically calculated based on BPM.">i</abbr>
       <label for="notespacing">Note Spacing</label>
-      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" value="180" placeholder="Auto">
+      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" placeholder="Auto">
 
       <abbr title="Color of the start of the note">i</abbr>
       <label for="notestartcolor">Note Start Color</label>
@@ -286,8 +287,16 @@
   <div class="container">
     <h2>Version history</h2>
     <p>
-      v1.9b<br>
+      v1.10<br>
+      Added an option to automatically detect and fix note gaps that might be too short.
+    </p>
+    <p>
+      v1.9c<br>
       Made Note Spacing optional. Default will automatically calculate based on 100/BPM*300 if Note Spacing is empty.
+    </p>
+    <p>
+      v1.9b<br>
+      If the MIDI has tempo change meta events, the chart's bpm will be automatically added to the form.
     </p>
     <p>
       v1.9a<br>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
       <abbr
         title="The higher this is, the faster the chart will scroll and the fewer notes will be on the screen at once. If left blank the spacing will be automatically calculated based on BPM.">i</abbr>
       <label for="notespacing">Note Spacing</label>
-      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" placeholder="Auto">
+      <input type="number" id="notespacing" name="notespacing" min="1" max="1000" value="180" placeholder="Auto">
 
       <abbr title="Color of the start of the note">i</abbr>
       <label for="notestartcolor">Note Start Color</label>
@@ -287,7 +287,7 @@
     <h2>Version history</h2>
     <p>
       v1.9b<br>
-      Made Note Spacing optional. Default will automatically calculate based on 100/BPM*300
+      Made Note Spacing optional. Default will automatically calculate based on 100/BPM*300 if Note Spacing is empty.
     </p>
     <p>
       v1.9a<br>

--- a/src/generate.js
+++ b/src/generate.js
@@ -8,7 +8,7 @@ const Generate = (function () {
     if (!Inputs.verifyInputs() || MidiToNotes.notes.length === 0) {
       alert(
         "Please ensure a valid midi is uploaded and all fields are filled\n" +
-          "(Song Endpoint can be empty)"
+          "(Song Endpoint and Note Spacing can be empty)"
       );
       return;
     }
@@ -17,6 +17,7 @@ const Generate = (function () {
 
     const chart = {
       ...inputs,
+      savednotespacing: inputs.savednotespacing || Math.ceil(100 / inputs.tempo * 300),
       notes: MidiToNotes.notes,
       lyrics: MidiToNotes.lyrics,
       trackRef: (inputs.prefixTrackRef ? Math.random().toString().substring(2) + '_' : '') + inputs.trackRef,

--- a/src/generate.js
+++ b/src/generate.js
@@ -17,7 +17,8 @@ const Generate = (function () {
 
     const chart = {
       ...inputs,
-      savednotespacing: inputs.savednotespacing || Math.ceil(100 / inputs.tempo * 300),
+      tempo: inputs.tempo || MidiToNotes.calculatedBPM,
+      savednotespacing: inputs.savednotespacing || Inputs.calculatedSpacing,
       notes: MidiToNotes.notes,
       lyrics: MidiToNotes.lyrics,
       trackRef: (inputs.prefixTrackRef ? Math.random().toString().substring(2) + '_' : '') + inputs.trackRef,

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -118,10 +118,10 @@ const Inputs = (function () {
     return num;
   }
 
-  function calculateSpacing() {
-    let activeBPM = Inputs.inputs["bpm"].value || MidiToNotes.calculatedBPM
-    Inputs.calculatedSpacing = Math.ceil(100 / activeBPM * 300) || "Auto"
-    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing
+  function calculateNoteSpacing() {
+    let activeBPM = Inputs.inputs["bpm"].value || MidiToNotes.calculatedBPM;
+    Inputs.calculatedSpacing = Math.ceil(100 / activeBPM * 300) || "Auto";
+    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing;
   }
 
   Init.register(function () {
@@ -133,9 +133,9 @@ const Inputs = (function () {
 
     // Automatically calculate default Spacing whenever the BPM changes.
     document
-    .getElementById("bpm")
-    .addEventListener("change", calculateSpacing);
+      .getElementById("bpm")
+      .addEventListener("change", calculateNoteSpacing());
   });
 
-  return { inputs, readColors, readInputs, verifyInputs, writeInputs };
+  return { inputs, readColors, readInputs, verifyInputs, writeInputs, calculateNoteSpacing };
 })();

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -22,7 +22,10 @@ const Inputs = (function () {
   };
 
   /** Inputs that are not required to be filled in */
-  const optionalInputNames = new Set(["songendpoint"]);
+  const optionalInputNames = new Set([
+    "notespacing",
+    "songendpoint",
+  ]);
 
   /** Inputs that need to be formatted as ints */
   const intInputNames = new Set([
@@ -32,6 +35,7 @@ const Inputs = (function () {
     "songendpoint",
     "beatsperbar",
   ]);
+
   /** Inputs that need to be formatted as floats */
   const floatInputNames = new Set([
     "bpm",

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -50,7 +50,7 @@ const Inputs = (function () {
   /** Returns whether all required fields are filled in */
   function verifyInputs() {
     for (const [inputName, input] of Object.entries(inputs)) {
-      if (!optionalInputNames.has(inputName) && !input.value) {
+      if (!optionalInputNames.has(inputName) && !input.value && !MidiToNotes.calculatedBPM) {
         return false;
       }
     }
@@ -118,12 +118,23 @@ const Inputs = (function () {
     return num;
   }
 
+  function calculateSpacing() {
+    let activeBPM = Inputs.inputs["bpm"].value || MidiToNotes.calculatedBPM
+    Inputs.calculatedSpacing = Math.ceil(100 / activeBPM * 300) || "Auto"
+    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing
+  }
+
   Init.register(function () {
     for (const inputName of Object.keys(inputMap)) {
       const input = document.getElementById(inputName);
       if (!input) throw `Could not find input: ${inputName}`;
       inputs[inputName] = input;
     }
+
+    // Automatically calculate default Spacing whenever the BPM changes.
+    document
+    .getElementById("bpm")
+    .addEventListener("change", calculateSpacing);
   });
 
   return { inputs, readColors, readInputs, verifyInputs, writeInputs };

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -120,8 +120,8 @@ const Inputs = (function () {
 
   function calculateNoteSpacing() {
     let activeBPM = Inputs.inputs["bpm"].value || MidiToNotes.calculatedBPM;
-    Inputs.calculatedSpacing = Math.ceil(100 / activeBPM * 300) || "Auto";
-    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing;
+    Inputs.calculatedSpacing = Math.ceil(100 / activeBPM * 300);
+    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing || "Auto";
   }
 
   Init.register(function () {
@@ -134,7 +134,7 @@ const Inputs = (function () {
     // Automatically calculate default Spacing whenever the BPM changes.
     document
       .getElementById("bpm")
-      .addEventListener("change", calculateNoteSpacing());
+      .addEventListener("change", calculateNoteSpacing);
   });
 
   return { inputs, readColors, readInputs, verifyInputs, writeInputs, calculateNoteSpacing };

--- a/src/midiToNotes.js
+++ b/src/midiToNotes.js
@@ -20,7 +20,7 @@ const MidiToNotes = (function () {
     collectPitchBendEvents(sortedMidiEvents);
 
     Inputs.inputs["bpm"].placeholder = MidiToNotes.calculatedBPM || ""
-    Inputs.calculatedSpacing = Math.ceil(100 / MidiToNotes.calculatedBPM * 300) || "Enter BPM" // scuffed to have one extra copy of this but I couldn't figure something out yet
+    Inputs.calculatedSpacing = Math.ceil(100 / MidiToNotes.calculatedBPM * 300) || "Auto" // duplicate from inputs.js.calculateSpacing() but I idk how to make it callable from here also sorry for the needlessly long comment that I am fully aware of making worse by writing this apology for the length of this comment but at this point I just found it funny, it's gotta go anyways.
     Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing
 
     // Calculate endpoint

--- a/src/midiToNotes.js
+++ b/src/midiToNotes.js
@@ -248,6 +248,8 @@ const MidiToNotes = (function () {
     /**
      * Value from the first tempo change, measured in microseconds per quarter note.
      * MIDI files use a default of 500,000 (120 bpm) if no tempo event is provided.
+     * If the original BPM value doesn't convert to microseconds cleanly,
+     * the result is rounded which causes a conversion back to BPM to be slightly off.
      */
     let baseTempo = 500000;
     /** Value from the last tempo change, measured in microseconds per quarter note */
@@ -260,7 +262,7 @@ const MidiToNotes = (function () {
         if (event.time === 0)
           baseTempo = event.data;
         currTempo = event.data;
-          MidiToNotes.calculatedBPM = 60000000 / baseTempo
+          MidiToNotes.calculatedBPM = parseFloat((60000000 / baseTempo).toPrecision(6))
       }
 
       let adjustedDeltaTime = event.deltaTime * currTempo / baseTempo;

--- a/src/midiToNotes.js
+++ b/src/midiToNotes.js
@@ -19,9 +19,9 @@ const MidiToNotes = (function () {
     adjustForTempoChanges(sortedMidiEvents);
     collectPitchBendEvents(sortedMidiEvents);
 
-    Inputs.inputs["bpm"].placeholder = MidiToNotes.calculatedBPM || ""
-    Inputs.calculatedSpacing = Math.ceil(100 / MidiToNotes.calculatedBPM * 300) || "Auto" // duplicate from inputs.js.calculateSpacing() but I idk how to make it callable from here also sorry for the needlessly long comment that I am fully aware of making worse by writing this apology for the length of this comment but at this point I just found it funny, it's gotta go anyways.
-    Inputs.inputs["notespacing"].placeholder = Inputs.calculatedSpacing
+    // Calculate Tempo (if possible) and Note Spacing.
+    Inputs.inputs["bpm"].placeholder = MidiToNotes.calculatedBPM || "";
+    Inputs.calculateNoteSpacing();
 
     // Calculate endpoint
     for (let i = sortedMidiEvents.length - 1; i >= 0; i--) {
@@ -257,12 +257,14 @@ const MidiToNotes = (function () {
 
     let currTime = 0;
 
+    MidiToNotes.calculatedBPM = undefined;
+
     for (const event of sortedMidiEvents) {
       if (getEventType(event) === "meta" && event.metaType === 81) {
         if (event.time === 0)
           baseTempo = event.data;
         currTempo = event.data;
-          MidiToNotes.calculatedBPM = parseFloat((60000000 / baseTempo).toPrecision(6))
+          MidiToNotes.calculatedBPM = parseFloat((60000000 / baseTempo).toPrecision(6));
       }
 
       let adjustedDeltaTime = event.deltaTime * currTempo / baseTempo;


### PR DESCRIPTION
No more manually calculating the most recommended default yay

**Background:**
The equasion 100/BPM*300 turns the BPM into a multiplier to replicate the ingame scroll speed you get on a chart with a tempo of 100 and savednotespacing of 300.
This will always give you a consistent scroll speed regardless of BPM.
The number 300 was chosen because its decently adequate across pretty much any kind of chart, from a simple one like Warm-Up to crazy ones like Parallel Universe Shifter.