### PR TITLE
If MIDI has tempo events, BPM is added automatically.

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,6 +286,10 @@
   <div class="container">
     <h2>Version history</h2>
     <p>
+      v1.9c<br>
+      If the midi has tempo changes, the appropiate tempo is now added automatically.
+    </p>
+    <p>
       v1.9b<br>
       Fixed an issue where tempo changes were applied at the wrong time
     </p>

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
     <h2>Version history</h2>
     <p>
       v1.9c<br>
-      If the midi has tempo changes, the appropiate tempo is now added automatically.
+      If the midi has tempo change events, the appropiate BPM is now automatically added to the field.
     </p>
     <p>
       v1.9b<br>

--- a/index.html
+++ b/index.html
@@ -286,6 +286,10 @@
   <div class="container">
     <h2>Version history</h2>
     <p>
+      v1.9c<br>
+      If the midi has tempo change events, the appropiate BPM is now automatically added to the field.
+    </p>
+    <p>
       v1.9b<br>
       Fixed an issue where tempo changes were applied at the wrong time
     </p>

--- a/src/generate.js
+++ b/src/generate.js
@@ -17,6 +17,7 @@ const Generate = (function () {
 
     const chart = {
       ...inputs,
+      tempo: inputs.tempo || MidiToNotes.calculatedBPM,
       notes: MidiToNotes.notes,
       lyrics: MidiToNotes.lyrics,
       trackRef: (inputs.prefixTrackRef ? Math.random().toString().substring(2) + '_' : '') + inputs.trackRef,

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -46,7 +46,7 @@ const Inputs = (function () {
   /** Returns whether all required fields are filled in */
   function verifyInputs() {
     for (const [inputName, input] of Object.entries(inputs)) {
-      if (!optionalInputNames.has(inputName) && !input.value) {
+      if (!optionalInputNames.has(inputName) && !input.value && !MidiToNotes.calculatedBPM) {
         return false;
       }
     }

--- a/src/midiToNotes.js
+++ b/src/midiToNotes.js
@@ -19,6 +19,10 @@ const MidiToNotes = (function () {
     adjustForTempoChanges(sortedMidiEvents);
     collectPitchBendEvents(sortedMidiEvents);
 
+    // Calculate Tempo (if possible) and Note Spacing.
+    Inputs.inputs["bpm"].placeholder = MidiToNotes.calculatedBPM || "";
+    Inputs.calculateNoteSpacing();
+
     // Calculate endpoint
     for (let i = sortedMidiEvents.length - 1; i >= 0; i--) {
       const eventType = getEventType(sortedMidiEvents[i]);
@@ -243,12 +247,16 @@ const MidiToNotes = (function () {
     /**
      * Value from the first tempo change, measured in microseconds per quarter note.
      * MIDI files use a default of 500,000 (120 bpm) if no tempo event is provided.
+     * If the original BPM value doesn't convert to microseconds cleanly,
+     * the result is rounded which causes a conversion back to BPM to be slightly off.
      */
     let baseTempo = 500000;
     /** Value from the last tempo change, measured in microseconds per quarter note */
     let currTempo = baseTempo;
 
     let currTime = 0;
+
+    MidiToNotes.calculatedBPM = undefined; // reset for new files.
 
     for (const event of sortedMidiEvents) {
       let adjustedDeltaTime = event.deltaTime * currTempo / baseTempo;
@@ -257,6 +265,7 @@ const MidiToNotes = (function () {
       if (getEventType(event) === "meta" && event.metaType === 81) {
         if (event.time === 0) baseTempo = event.data;
         currTempo = event.data;
+        MidiToNotes.calculatedBPM = parseFloat((60000000 / baseTempo).toPrecision(6));
       }
     }
   }

--- a/src/midiToNotes.js
+++ b/src/midiToNotes.js
@@ -19,6 +19,9 @@ const MidiToNotes = (function () {
     adjustForTempoChanges(sortedMidiEvents);
     collectPitchBendEvents(sortedMidiEvents);
 
+    // Calculate Tempo (if possible) and Note Spacing.
+    Inputs.inputs["bpm"].placeholder = MidiToNotes.calculatedBPM || "";
+
     // Calculate endpoint
     for (let i = sortedMidiEvents.length - 1; i >= 0; i--) {
       const eventType = getEventType(sortedMidiEvents[i]);
@@ -243,12 +246,16 @@ const MidiToNotes = (function () {
     /**
      * Value from the first tempo change, measured in microseconds per quarter note.
      * MIDI files use a default of 500,000 (120 bpm) if no tempo event is provided.
+     * If the original BPM value doesn't convert to microseconds cleanly,
+     * the result is rounded which causes a conversion back to BPM to be slightly off.
      */
     let baseTempo = 500000;
     /** Value from the last tempo change, measured in microseconds per quarter note */
     let currTempo = baseTempo;
 
     let currTime = 0;
+
+    MidiToNotes.calculatedBPM = undefined; // reset for new files.
 
     for (const event of sortedMidiEvents) {
       let adjustedDeltaTime = event.deltaTime * currTempo / baseTempo;
@@ -257,6 +264,7 @@ const MidiToNotes = (function () {
       if (getEventType(event) === "meta" && event.metaType === 81) {
         if (event.time === 0) baseTempo = event.data;
         currTempo = event.data;
+        MidiToNotes.calculatedBPM = parseFloat((60000000 / baseTempo).toPrecision(6));
       }
     }
   }


### PR DESCRIPTION
Since BPM is detected and adjusted for anyways I thought might as well add automatically it to the input field as well.