### PR TITLE
Fix to parsing of unimplemented meta events

### DIFF
--- a/lib/midi-converter.js
+++ b/lib/midi-converter.js
@@ -260,6 +260,8 @@
                                 // if no customInterpretr is provided, or returned
                                 // false (=apply default), perform default action
                                 if(this.customInterpreter === null || MIDI.track[t-1].event[e-1].data === false){
+                                    // PATCH: https://github.com/colxi/midi-parser-js/pull/20
+                                    // file.readInt(metaEventLength);
                                     MIDI.track[t-1].event[e-1].data = file.readInt(metaEventLength);
                                     if (this.debug) console.info('Unimplemented 0xFF meta event! data block readed as Integer');
                                 }

--- a/lib/midi-converter.js
+++ b/lib/midi-converter.js
@@ -260,7 +260,6 @@
                                 // if no customInterpretr is provided, or returned
                                 // false (=apply default), perform default action
                                 if(this.customInterpreter === null || MIDI.track[t-1].event[e-1].data === false){
-                                    file.readInt(metaEventLength);
                                     MIDI.track[t-1].event[e-1].data = file.readInt(metaEventLength);
                                     if (this.debug) console.info('Unimplemented 0xFF meta event! data block readed as Integer');
                                 }


### PR DESCRIPTION
I've seen people run into this issue twice on discord now, and the fix is literally to remove one single line of code lol.

Short summary: If there's an undefined meta event in the midi, the parser goofs and reads twice as far along as it should. The fix has already been an open pr on the parser for almost 4 years: https://github.com/colxi/midi-parser-js/pull/20