### PR TITLE
Add charter field

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
 
       <h3>- Other -</h3>
 
-      <abbr title="Composer or author of the song (optional)">i</abbr>
+      <abbr title="Who made this chart (optional)">i</abbr>
       <label for="charter">Charter</label>
       <input type="text" id="charter" name="charter">
 

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
 
       <h3>- Other -</h3>
 
-      <abbr title="Composer or author of the song">i</abbr>
+      <abbr title="Composer or author of the song (optional)">i</abbr>
       <label for="charter">Charter</label>
       <input type="text" id="charter" name="charter">
 

--- a/index.html
+++ b/index.html
@@ -303,6 +303,10 @@
   <div class="container">
     <h2>Version history</h2>
     <p>
+      v1.11a<br>
+      Added charter field.
+    </p>
+    <p>
       v1.11<br>
       Added support for background events
     </p>

--- a/index.html
+++ b/index.html
@@ -143,6 +143,10 @@
 
       <h3>- Other -</h3>
 
+      <abbr title="Composer or author of the song">i</abbr>
+      <label for="charter">Charter</label>
+      <input type="text" id="charter" name="charter">
+
       <abbr title="Name used by mods to identify your chart. Use only a-Z, 1-9, _, -, and space. Should be globally unique.">i</abbr>
       <label for="trackRef">trackRef</label>
       <input type="text" id="trackRef" name="trackRef">

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -23,7 +23,7 @@ const Inputs = (function () {
   };
 
   /** Inputs that are not required to be filled in */
-  const optionalInputNames = new Set(["songendpoint"]);
+  const optionalInputNames = new Set(["songendpoint", "charter"]);
 
   /** Inputs that need to be formatted as ints */
   const intInputNames = new Set([

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -7,6 +7,7 @@ const Inputs = (function () {
     songname: "name",
     shortname: "shortName",
     artist: "author",
+    charter: "charter",
     releaseyear: "year",
     genre: "genre",
     description: "description",


### PR DESCRIPTION
The game uses a charter field in tootmaker to denote who made the chart. I like that, I feel like it's a better option than putting a "charted by username" tag in the description so like to add it to charts.

Right now it doesn't really do anything outside of tootmaker but I think it could be really useful for modded games.
Hmm Maybe I should ask about that first.